### PR TITLE
Prep for 1.0.0 release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,14 +48,16 @@ workflows:
     jobs:
       # Integration test jobs go here
       - stackhawk/hawkscan-remote:
-          app-id: "${HAWK_APP_ID}"
+          app-id: 640b8e32-2682-42f9-9a5c-78cc746e3284
           env: "${CIRCLE_BRANCH}"
+          host: http://example.com
           docker-image: stackhawk/hawkscan:beta
 
       - stackhawk/hawkscan-local:
-          app-id: "${HAWK_APP_ID}"
+          app-id: c75c2985-e8eb-4243-9d73-7c9a2c10807f
           env: "${CIRCLE_BRANCH}"
           docker-network: scan_net
+          host: http://nginx_test
           steps:
             - run:
                 name: Create scan_net Network

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,7 +47,7 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       # Integration test jobs go here
-      - hawkscan-remote:
+      - stackhawk/hawkscan-remote:
           app-id: "${HAWK_APP_ID}"
           env: "${CIRCLE_BRANCH}"
           docker-image: stackhawk/hawkscan:beta

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,9 +47,10 @@ workflows:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
       # Integration test jobs go here
-#      - hawkscan-remote:
-#          app-id: "${HAWK_APP_ID}"
-#          env: "${CIRCLE_BRANCH}"
+      - hawkscan-remote:
+          app-id: "${HAWK_APP_ID}"
+          env: "${CIRCLE_BRANCH}"
+          docker-image: stackhawk/hawkscan:beta
 
       - stackhawk/hawkscan-local:
           app-id: "${HAWK_APP_ID}"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🦅 StackHawk CircleCI Orb
 
-The CircleCI Orb, [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/stackhawk/stackhawk) makes it easy to integrate StackHawk into your continuous integration pipeline.
+The CircleCI Orb [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/stackhawk/stackhawk) makes it easy to integrate StackHawk into your continuous integration pipeline.
 
 ## About StackHawk
 [StackHawk](https://stackhawk.com) provides dynamic application vulnerability scanning from development to production.

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The CircleCI Orb [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/
 ## About StackHawk
 [StackHawk](https://stackhawk.com) provides dynamic application vulnerability scanning from development to production.
 
-  * ⚡ Dynamic Application Scanning: Use HawkScan for dynamic vulnerability scanning of your web apps. Think of it as continuous pen testing or security integration testing. Get started with your first scan in minutes.
+  * ⚡ Dynamic Application Scanning: Use HawkScan to find and fix security bugs in your web apps, before you push to production. Think of it as security integration testing. [Get started](https://docs.stackhawk.com/hawkscan/getting-started.html) with your first scan in minutes.
   * 🦸‍ ️Built for Modern Dev Teams: Automate scans with Docker commands, manage configs via YAML, and add app scanning as a build stage. We're built for dev teams that care about security and quality.
-  * 🧰 Vulnerability Management: (coming soon!) Document for compliance. Prioritize and manage fixes with integrations to existing ticketing tools. No more quarterly pen test PDFs - there is a better way.
+  * 🧰 Vulnerability Management: (coming soon!) Document for compliance. Prioritize and manage fixes with integrations to existing ticketing tools. Point in time assements are a thing of the past - there is a better way.
 
 Use the HawkScan command line tool to run application scans manually or through automation. Use the stackhawk/stackhawk Orb to make it simple to run it in CircleCI.
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ The CircleCI Orb [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/
 ## About StackHawk
 [StackHawk](https://stackhawk.com) provides dynamic application vulnerability scanning from development to production.
 
-  * ⚡ Dynamic Application Scanning: Use HawkScan to find and fix security bugs in your web apps, before you push to production. Think of it as security integration testing. [Get started](https://docs.stackhawk.com/hawkscan/getting-started.html) with your first scan in minutes.
-  * 🦸‍ ️Built for Modern Dev Teams: Automate scans with Docker commands, manage configs via YAML, and add app scanning as a build stage. We're built for dev teams that care about security and quality.
-  * 🧰 Vulnerability Management: (coming soon!) Document for compliance. Prioritize and manage fixes with integrations to existing ticketing tools. Point in time assements are a thing of the past - there is a better way.
+  * ⚡ **Dynamic Application Scanning:** Use HawkScan to find and fix security bugs in your web apps, before you push to production. Think of it as security integration testing. [Get started](https://docs.stackhawk.com/hawkscan/getting-started.html) with your first scan in minutes.
+  * 🦸 **Built for Modern Dev Teams:** Automate scans with Docker commands, manage configs via YAML, and add app scanning as a build stage. We're built for dev teams that care about security and quality.
+  * 🧰 **Vulnerability Management:** (coming soon!) Document for compliance. Prioritize and manage fixes with integrations to existing ticketing tools. Point in time assessments are a thing of the past - there is a better way.
 
 Use the HawkScan command line tool to run application scans manually or through automation. Use the stackhawk/stackhawk Orb to make it simple to run it in CircleCI.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
-# CircleCI Orb stackhawk/stackhawk
+# StackHawk CircleCI Orb
 
-This project contains the CircleCI Orb, `stackhawk/stackhawk`.
+This project contains the CircleCI Orb, `stackhawk/stackhawk`. See https://circleci.com/orbs/registry/orb/stackhawk/stackhawk for more details.
 
-Visit https://circleci.com/orbs/registry/orb/stackhawk/stackhawk for more information.
+## Sign Up!
+To use this Orb, you must have a StackHawk API key. Visit https://stackhawk.com to get yours.
 
+## Configure HawkScan!
+To start scanning your application, create a `stackhawk.yml` configuration file in your app's source repository. Read the docs at https://docs.stackhawk.com/.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🦅 StackHawk CircleCI Orb
 
-The CircleCI Orb, [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/stackhawk/stackhawk), which makes it easy to integrate StackHawk into your continuous integration pipeline.
+The CircleCI Orb, [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/stackhawk/stackhawk) makes it easy to integrate StackHawk into your continuous integration pipeline.
 
 ## About StackHawk
 [StackHawk](https://stackhawk.com) provides dynamic application vulnerability scanning from development to production.
@@ -17,4 +17,7 @@ Use the HawkScan command line tool to run application scans manually or through 
 To use this Orb, you must have a StackHawk API key. [Sign up](https://stackhawk.com) to get yours.
 
 ## Configure HawkScan
-To start scanning your application, create a `stackhawk.yml` configuration file in your application source repository. [Read the docs](https://docs.stackhawk.com/) for more details.
+To scan your application, you will need a `stackhawk.yml` configuration file in your application source repository. [Read the docs](https://docs.stackhawk.com/) for more details.
+
+## KAAKAWW!
+That is all.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,20 @@
-# StackHawk CircleCI Orb
+[![StackHawk](https://www.stackhawk.com/wp-content/uploads/2019/07/stackhawk-long.png)](https://stackhawk.com)
 
-This project contains the CircleCI Orb, `stackhawk/stackhawk`. See https://circleci.com/orbs/registry/orb/stackhawk/stackhawk for more details.
+# 🦅 StackHawk CircleCI Orb
 
-## Sign Up!
-To use this Orb, you must have a StackHawk API key. Visit https://stackhawk.com to get yours.
+The CircleCI Orb, [`stackhawk/stackhawk`](https://circleci.com/orbs/registry/orb/stackhawk/stackhawk), which makes it easy to integrate StackHawk into your continuous integration pipeline.
 
-## Configure HawkScan!
-To start scanning your application, create a `stackhawk.yml` configuration file in your app's source repository. Read the docs at https://docs.stackhawk.com/.
+## About StackHawk
+[StackHawk](https://stackhawk.com) provides dynamic application vulnerability scanning from development to production.
+
+  * ⚡ Dynamic Application Scanning: Use HawkScan for dynamic vulnerability scanning of your web apps. Think of it as continuous pen testing or security integration testing. Get started with your first scan in minutes.
+  * 🦸‍ ️Built for Modern Dev Teams: Automate scans with Docker commands, manage configs via YAML, and add app scanning as a build stage. We're built for dev teams that care about security and quality.
+  * 🧰 Vulnerability Management: (coming soon!) Document for compliance. Prioritize and manage fixes with integrations to existing ticketing tools. No more quarterly pen test PDFs - there is a better way.
+
+Use the HawkScan command line tool to run application scans manually or through automation. Use the stackhawk/stackhawk Orb to make it simple to run it in CircleCI.
+
+## Sign Up
+To use this Orb, you must have a StackHawk API key. [Sign up](https://stackhawk.com) to get yours.
+
+## Configure HawkScan
+To start scanning your application, create a `stackhawk.yml` configuration file in your application source repository. [Read the docs](https://docs.stackhawk.com/) for more details.

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,7 +2,7 @@
 version: 2.1
 
 description: >
-  Automate dynamic security scanning in your build pipeline. A stackhawk.com API key is required.
+  Automate dynamic application security testing in your pipeline.
 
 display:
   source_url: https://github.com/stackhawk/stackhawk-orb

--- a/src/examples/hawkscan-local-container.yml
+++ b/src/examples/hawkscan-local-container.yml
@@ -1,13 +1,16 @@
 ---
 description: |
-  In this example, we will run Nginx as a Docker container to be scanned within the CircleCI
-  build environment. We run the stackhawk/hawkscan-local job with the parameter `docker-network: scan_net` to tell
-  HawkScan to run on the Docker named network, `scan_net`. We also provide the
-  parameter `steps` to 1) create a named Docker bridge network, `scan_net`, and 2) run an nginx container on that
-  network with the name `nginx_test`.
+  In this example, we run Nginx as a Docker container to be scanned within the CircleCI build environment.
+
+  We run the `stackhawk/hawkscan-local` job with the parameter `docker-network: scan_net` to tell HawkScan to run on
+  the Docker named network, `scan_net`.
+
+  We also provide the parameter `steps` to do the following before the scan runs:
+    1) Create a named Docker bridge network, `scan_net`
+    2) Run an Nginx container on that network with the name `nginx_test`
 
   In our HawkScan configuration, we add our test subject, the nginx container, as `app.host: http://nginx_test`.
-  This example assumes you have stored your StackHawk API key as a protected environment variable, HAWK_API_KEY.
+  This example assumes you have stored your StackHawk API key as a protected environment variable, `HAWK_API_KEY`.
 
 usage:
   version: 2.1

--- a/src/examples/hawkscan-local-container.yml
+++ b/src/examples/hawkscan-local-container.yml
@@ -1,16 +1,16 @@
 ---
 description: |
-  In this example, we run Nginx as a Docker container to be scanned within the CircleCI build environment.
+  In this example, run Nginx as a Docker container and scan it within the CircleCI build environment.
 
-  We run the `stackhawk/hawkscan-local` job with the parameter `docker-network: scan_net` to tell HawkScan to run on
+  Run the `stackhawk/hawkscan-local` job with the parameter `docker-network: scan_net` to tell HawkScan to run on
   the Docker named network, `scan_net`.
 
-  We also provide the parameter `steps` to do the following before the scan runs:
+  Provide the parameter `steps` to do the following before the scan runs:
     1) Create a named Docker bridge network, `scan_net`
     2) Run an Nginx container on that network with the name `nginx_test`
 
-  In our HawkScan configuration, we add our test subject, the nginx container, as `app.host: http://nginx_test`.
-  This example assumes you have stored your StackHawk API key as a protected environment variable, `HAWK_API_KEY`.
+  The HawkScan configuration is read from our source repository as `./stackhawk.yml`. In that file, the test
+  subject is defined as `app.host=http://nginx_test`.
 
 usage:
   version: 2.1

--- a/src/examples/hawkscan-remote.yml
+++ b/src/examples/hawkscan-remote.yml
@@ -1,10 +1,14 @@
 ---
 description: |
-  In this example, we will run a standard HawkScan scan against a target host defined in your `stackhawk.yml`
-  configuration file within your source repository. This should be an integration environment
-  accessable to CircleCI. Just as an example, we also add a second overlay configuration file, `stackhawk-circlci.yml`.
+  In this example, run a scan against a remote target host defined in `stackhawk.yml` at the base of the source
+  repository.
 
-  This example assumes you have stored your StackHawk API key as a protected environment variable, `HAWK_API_KEY`.
+  Run stackhawk/hawkscan-remote with the configuration-files parameter, `stackhawk.yml stackhawk-circleci.yml`. This
+  tells HawkScan to use the `stackhawk.yml` configuration file found at the base of the source repository, and to
+  overlay it with configurations in `stackhawk-circleci.yml`.
+
+  Finally, add the host parameter, `http://example.com`. This adds a HOST environment variable to the HawkScan container
+  which may be interpolated in the `stackhawk.yml` configuration file.
 
 usage:
   version: 2.1
@@ -15,3 +19,4 @@ usage:
       jobs:
         - stackhawk/hawkscan-remote:
             configuration-files: stackhawk.yml stackhawk-circleci.yml
+            host: http://example.com

--- a/src/examples/hawkscan-remote.yml
+++ b/src/examples/hawkscan-remote.yml
@@ -1,10 +1,10 @@
 ---
 description: |
   In this example, we will run a standard HawkScan scan against a target host defined in your `stackhawk.yml`
-  configuration file within your source repository. In your case, this should be an integration environment
-  accessable to CircleCI. In this example, it's just `http://example.com`
+  configuration file within your source repository. This should be an integration environment
+  accessable to CircleCI. Just as an example, we also add a second overlay configuration file, `stackhawk-circlci.yml`.
 
-  This example assumes you have stored your StackHawk API key as a protected environment variable, HAWK_API_KEY.
+  This example assumes you have stored your StackHawk API key as a protected environment variable, `HAWK_API_KEY`.
 
 usage:
   version: 2.1
@@ -13,4 +13,5 @@ usage:
   workflows:
     scan-remote:
       jobs:
-        - stackhawk/hawkscan-remote
+        - stackhawk/hawkscan-remote:
+            configuration-files: stackhawk.yml stackhawk-circleci.yml

--- a/src/jobs/hawkscan-local.yml
+++ b/src/jobs/hawkscan-local.yml
@@ -15,6 +15,18 @@ parameters:
       Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the variable here.
     type: env_var_name
     default: "HAWK_API_KEY"
+  configuration-files:
+    description: >
+      A list of HawkScan configuration files to load. Defaults to `stackhawk.yml`. To overlay multiple configuration
+      files, separate them with spaces, e.g. `stackhawk1.yml stackhawk2.yml stackhawk3.yml`.
+    type: string
+    default: stackhawk.yml
+  docker-network:
+    description: >
+      Optional Docker named bridge network on which to run the HawkScan container, such as `scan-net`. Defaults to the
+      Docker default bridge named `bridge`.
+    type: string
+    default: bridge
   app-id:
     description: >
       Pass a value to the HawkScan runtime environment variable, `${APP_ID}`. You can use this environment variable in
@@ -59,23 +71,11 @@ parameters:
       Set to `true` if you want HawkScan to output in color. Color output may appear garbled in job output screens.
     type: boolean
     default: false
-  configuration-files:
-    description: >
-      A list of HawkScan configuration files to load. Defaults to `stackhawk.yml`. To overlay multiple configuration
-      files, separate them with spaces, e.g. `stackhawk1.yml stackhawk2.yml stackhawk3.yml`.
-    type: string
-    default: stackhawk.yml
   docker-image:
     description: >
       The HawkScan container to download. Change this only if recommended by StackHawk Support.
     type: string
     default: stackhawk/hawkscan:latest
-  docker-network:
-    description: >
-      Optional Docker named bridge network on which to run the HawkScan container, such as `scan-net`. Defaults to the
-      Docker default bridge named `bridge`.
-    type: string
-    default: bridge
   auth-endpoint:
     description: >
       The authentication endpoint for HawkScan to use when submitting scan results. Change this only if recommended by

--- a/src/jobs/hawkscan-local.yml
+++ b/src/jobs/hawkscan-local.yml
@@ -1,18 +1,21 @@
 ---
-description: >
-  Run a scan of a local integration environment, such as a detached docker container, or a backgrounded web service.
+description: |
+  Run a scan of a local integration environment. This job runs on a VM and runs hawkscan from a Docker container on
+  that VM. You may provide a series of steps that result in a service running either natively on localhost, or as a
+  Docker container on a named Docker bridge network, such as `scan_net`.
+
+  If you have an integration environment running in a remote environment, you should use the stackhawk/hawkscan-remote
+  job instead. It's faster without the VM overhead.
+
+  This job requires a StackHawk API key to be stored as HAWK_API_KEY (default).
 
 machine: true
 
 parameters:
-  steps:
-    description: >
-      Any steps you wish to run before starting the scan. This must include starting a service or Docker container
-      that is to be the target of the scan.
-    type: steps
   api-key:
     description: >
-      Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the variable here.
+      Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the name of the variable
+      here.
     type: env_var_name
     default: "HAWK_API_KEY"
   configuration-files:
@@ -27,41 +30,46 @@ parameters:
       Docker default bridge named `bridge`.
     type: string
     default: bridge
+  steps:
+    description: >
+      Any steps you wish to run before starting the scan. This should include starting a service or Docker container
+      that is to be the target of the scan.
+    type: steps
   app-id:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${APP_ID}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, APP_ID. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.applicationId`, or any other parameter.
     type: string
     default: ""
   host:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${HOST}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, HOST. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.host`, or any other parameter.
     type: string
     default: ""
   env:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${ENV}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, ENV. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.env`, or any other parameter.
     type: string
     default: ""
   username:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${USERNAME}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, USERNAME. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.usernamePassword.scanUsername`, or any
       other parameter.
     type: string
     default: ""
   password:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${PASSWORD}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, PASSWORD. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.usernamePassword.scanPassword`, or any
       other parameter.
     type: string
     default: ""
   auth-token:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${AUTH_TOKEN}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, AUTH_TOKEN. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.external.value`, or any
       other parameter.
     type: string
@@ -83,7 +91,7 @@ parameters:
     type: string
     default: https://auth.stackhawk.com
   results-endpoint:
-    description:
+    description: >
       The API endpoint for HawkScan to use when submitting scan results. Change this only if recommended by StackHawk
       Support.
     type: string

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -80,14 +80,6 @@ parameters:
     default: https://api.stackhawk.com/api/v1
 
 environment:
-  SHAWK_AUTH_ENDPOINT: <<parameters.auth-endpoint>>
-  SHAWK_RESULTS_ENDPOINT: <<parameters.results-endpoint>>
-  NO_COLOR: <<parameters.color>>
-  HOST: <<#parameters.host>><<parameters.host>><</parameters.host>>
-  ENV: <<#parameters.env>><<parameters.env>><</parameters.env>>
-  USERNAME: <<#parameters.username>><<parameters.username>><</parameters.username>>
-  PASSWORD: <<#parameters.password>><<parameters.password>><</parameters.password>>
-  AUTH_TOKEN: <<#parameters.auth-token>><<parameters.auth-token>><</parameters.auth-token>>
   REPO_DIR: /home/zap/hawk
 
 working_directory: /home/zap/hawk
@@ -98,6 +90,14 @@ steps:
       name: HawkScan
       command: |
         echo 'export API_KEY=${<<parameters.api-key>>}' >> ${BASH_ENV}
-        <<#parameters.app-id>>echo 'export APP_ID=${<<parameters.app-id>>}' >> ${BASH_ENV}<</parameters.app-id>>
+        echo 'export SHAWK_AUTH_ENDPOINT=${<<parameters.auth-endpoint>>}' >> ${BASH_ENV}
+        echo 'export SHAWK_RESULTS_ENDPOINT=${<<parameters.results-endpoint>>}' >> ${BASH_ENV}
+        echo 'export NO_COLOR=${<<parameters.color>>}' >> ${BASH_ENV}
+        <<#parameters.app-id>>echo 'export APP_ID=<<parameters.app-id>>' >> ${BASH_ENV}<</parameters.app-id>>
+        <<#parameters.host>>echo 'export HOST=<<parameters.host>>' >> ${BASH_ENV}<</parameters.host>>
+        <<#parameters.env>>echo 'export ENV=<<parameters.env>>' >> ${BASH_ENV}<</parameters.env>>
+        <<#parameters.username>>echo 'export USERNAME=<<parameters.username>>' >> ${BASH_ENV}<</parameters.username>>
+        <<#parameters.password>>echo 'export PASSWORD=<<parameters.password>>' >> ${BASH_ENV}<</parameters.password>>
+        <<#parameters.auth-token>>echo 'export AUTH_TOKEN=<<parameters.auth-token>>' >> ${BASH_ENV}<</parameters.auth-token>>
         source ${BASH_ENV}
         shawk <<parameters.configuration-files>>

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -99,5 +99,6 @@ steps:
   - run:
       name: HawkScan
       command: |
-        export API_KEY="${<<parameters.api-key>>}"
+        echo 'export API_KEY=${<<parameters.api-key>>}' >> ${BASH_ENV}
+        source ${BASH_ENV}
         shawk <<parameters.configuration-files>>

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -13,7 +13,8 @@ docker:
 parameters:
   api-key:
     description: >
-      Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the variable here.
+      Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the name of the variable
+      here.
     type: env_var_name
     default: "HAWK_API_KEY"
   configuration-files:

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -82,9 +82,7 @@ parameters:
 environment:
   SHAWK_AUTH_ENDPOINT: <<parameters.auth-endpoint>>
   SHAWK_RESULTS_ENDPOINT: <<parameters.results-endpoint>>
-  API_KEY: <<parameters.api-key>>
   NO_COLOR: <<parameters.color>>
-  APP_ID: <<#parameters.app-id>><<parameters.app-id>><</parameters.app-id>>
   HOST: <<#parameters.host>><<parameters.host>><</parameters.host>>
   ENV: <<#parameters.env>><<parameters.env>><</parameters.env>>
   USERNAME: <<#parameters.username>><<parameters.username>><</parameters.username>>
@@ -100,5 +98,6 @@ steps:
       name: HawkScan
       command: |
         echo 'export API_KEY=${<<parameters.api-key>>}' >> ${BASH_ENV}
+        <<#parameters.app-id>>echo 'export APP_ID=${<<parameters.app-id>>}' >> ${BASH_ENV}<</parameters.app-id>>
         source ${BASH_ENV}
         shawk <<parameters.configuration-files>>

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -11,6 +11,12 @@ parameters:
       Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the variable here.
     type: env_var_name
     default: "HAWK_API_KEY"
+  configuration-files:
+    description: >
+      A list of HawkScan configuration files to load. Defaults to `stackhawk.yml`. To overlay multiple configuration
+      files, separate them with spaces, e.g. `stackhawk1.yml stackhawk2.yml stackhawk3.yml`.
+    type: string
+    default: stackhawk.yml
   app-id:
     description: >
       Pass a value to the HawkScan runtime environment variable, `${APP_ID}`. You can use this environment variable in
@@ -55,23 +61,11 @@ parameters:
       Set to `true` if you want HawkScan to output in color. Color output may appear garbled in job output screens.
     type: boolean
     default: false
-  configuration-files:
-    description: >
-      A list of HawkScan configuration files to load. Defaults to `stackhawk.yml`. To overlay multiple configuration
-      files, separate them with spaces, e.g. `stackhawk1.yml stackhawk2.yml stackhawk3.yml`.
-    type: string
-    default: stackhawk.yml
   docker-image:
     description: >
       The HawkScan container to download. Change this only if recommended by StackHawk Support.
     type: string
     default: stackhawk/hawkscan:latest
-  docker-network:
-    description: >
-      Optional Docker named bridge network on which to run the HawkScan container, such as `scan-net`. Defaults to the
-      Docker default bridge named `bridge`.
-    type: string
-    default: bridge
   auth-endpoint:
     description: >
       The authentication endpoint for HawkScan to use when submitting scan results. Change this only if recommended by
@@ -96,8 +90,9 @@ environment:
   USERNAME: <<#parameters.username>>"<<parameters.username>>"<</parameters.username>>
   PASSWORD: <<#parameters.password>>"<<parameters.password>>"<</parameters.password>>
   AUTH_TOKEN: <<#parameters.auth-token>>"<<parameters.auth-token>>"<</parameters.auth-token>>
+  REPO_DIR: /home/zap/hawk
 
-working_directory: /zap/hawk
+working_directory: /home/zap/hawk
 
 steps:
   - checkout

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -90,9 +90,9 @@ steps:
       name: HawkScan
       command: |
         echo 'export API_KEY=${<<parameters.api-key>>}' >> ${BASH_ENV}
-        echo 'export SHAWK_AUTH_ENDPOINT=${<<parameters.auth-endpoint>>}' >> ${BASH_ENV}
-        echo 'export SHAWK_RESULTS_ENDPOINT=${<<parameters.results-endpoint>>}' >> ${BASH_ENV}
-        echo 'export NO_COLOR=${<<parameters.color>>}' >> ${BASH_ENV}
+        echo 'export SHAWK_AUTH_ENDPOINT=<<parameters.auth-endpoint>>' >> ${BASH_ENV}
+        echo 'export SHAWK_RESULTS_ENDPOINT=<<parameters.results-endpoint>>' >> ${BASH_ENV}
+        echo 'export NO_COLOR=<<parameters.color>>' >> ${BASH_ENV}
         <<#parameters.app-id>>echo 'export APP_ID=<<parameters.app-id>>' >> ${BASH_ENV}<</parameters.app-id>>
         <<#parameters.host>>echo 'export HOST=<<parameters.host>>' >> ${BASH_ENV}<</parameters.host>>
         <<#parameters.env>>echo 'export ENV=<<parameters.env>>' >> ${BASH_ENV}<</parameters.env>>

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -80,16 +80,16 @@ parameters:
     default: https://api.stackhawk.com/api/v1
 
 environment:
-  SHAWK_AUTH_ENDPOINT: "<<parameters.auth-endpoint>>"
-  SHAWK_RESULTS_ENDPOINT: "<<parameters.results-endpoint>>"
-  API_KEY: "<<parameters.api-key>>"
-  NO_COLOR: "<<parameters.color>>"
-  APP_ID: <<#parameters.app-id>>"<<parameters.app-id>>"<</parameters.app-id>>
-  HOST: <<#parameters.host>>"<<parameters.host>>"<</parameters.host>>
-  ENV: <<#parameters.env>>"<<parameters.env>>"<</parameters.env>>
-  USERNAME: <<#parameters.username>>"<<parameters.username>>"<</parameters.username>>
-  PASSWORD: <<#parameters.password>>"<<parameters.password>>"<</parameters.password>>
-  AUTH_TOKEN: <<#parameters.auth-token>>"<<parameters.auth-token>>"<</parameters.auth-token>>
+  SHAWK_AUTH_ENDPOINT: <<parameters.auth-endpoint>>
+  SHAWK_RESULTS_ENDPOINT: <<parameters.results-endpoint>>
+  API_KEY: <<parameters.api-key>>
+  NO_COLOR: <<parameters.color>>
+  APP_ID: <<#parameters.app-id>><<parameters.app-id>><</parameters.app-id>>
+  HOST: <<#parameters.host>><<parameters.host>><</parameters.host>>
+  ENV: <<#parameters.env>><<parameters.env>><</parameters.env>>
+  USERNAME: <<#parameters.username>><<parameters.username>><</parameters.username>>
+  PASSWORD: <<#parameters.password>><<parameters.password>><</parameters.password>>
+  AUTH_TOKEN: <<#parameters.auth-token>><<parameters.auth-token>><</parameters.auth-token>>
   REPO_DIR: /home/zap/hawk
 
 working_directory: /home/zap/hawk

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -1,6 +1,11 @@
 ---
 description: >
-  Run a scan of a remote web app. This is the fastest way to run a scan of a known host.
+  This is the fastest way to run a scan of a known remote host.
+
+  This job requires a StackHawk API key to be stored as HAWK_API_KEY (default).
+
+  If you want to stand up a simple integration test locally, in the CircleCI build environment, you should use the
+  stackhawk/hawkscan-local job instead.
 
 docker:
   - image: <<parameters.docker-image>>
@@ -19,39 +24,39 @@ parameters:
     default: stackhawk.yml
   app-id:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${APP_ID}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, APP_ID. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.applicationId`, or any other parameter.
     type: string
     default: ""
   host:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${HOST}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, HOST. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.host`, or any other parameter.
     type: string
     default: ""
   env:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${ENV}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, ENV. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.env`, or any other parameter.
     type: string
     default: ""
   username:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${USERNAME}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, USERNAME. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.usernamePassword.scanUsername`, or any
       other parameter.
     type: string
     default: ""
   password:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${PASSWORD}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, PASSWORD. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.usernamePassword.scanPassword`, or any
       other parameter.
     type: string
     default: ""
   auth-token:
     description: >
-      Pass a value to the HawkScan runtime environment variable, `${AUTH_TOKEN}`. You can use this environment variable in
+      Pass a value to the HawkScan runtime environment variable, AUTH_TOKEN. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.external.value`, or any
       other parameter.
     type: string
@@ -73,7 +78,7 @@ parameters:
     type: string
     default: https://auth.stackhawk.com
   results-endpoint:
-    description:
+    description: >
       The API endpoint for HawkScan to use when submitting scan results. Change this only if recommended by StackHawk
       Support.
     type: string


### PR DESCRIPTION
This is a final revision before releasing 1.0.0 of the orb, and requesting review from CircleCI for their certification process.

This PR contains the following changes:
- Lots of self-documentation revisions to make it as simple as possible for users to understand how to use it
- Revision of the hawkscan-remote job to incorporate the HawkScan REPO_DIR beta feature