### PR TITLE
[semver:patch] Added resource-class parameter to the hawkscan-remote orb job

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,9 +11,9 @@ circleci orb pack src | circleci orb publish - stackhawk/stackhawk@dev:alpha
 
 ## Publishing a New Orb Version
 
-To publish a new version of this orb, push a commit to the `master` branch with a commit message that begins with the text, "`[semver:<patch|minor|major>]`." The CircleCI workflow will interpret that as a patch, minor, or major release and will update the version accordingly.
+To publish a new version of this orb, open a PR to the `master` branch.
 
-**IMPORTANT**: When you merge your PR, you must select squash merge and then add a merge commit message with [semver:<patch|minor|major>] in the message.
+**IMPORTANT**: When you merge your PR, you must select squash merge and then add a merge commit message with `[semver:<patch|minor|major>]` in the message. The CircleCI workflow will interpret that as a patch, minor, or major release and will update the version accordingly.
 
 ![squash merge](squashmerge.gif)
 

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -10,6 +10,8 @@ description: |
 docker:
   - image: <<parameters.docker-image>>
 
+resource_class: <<parameters.resource-class>>
+
 parameters:
   api-key:
     description: >
@@ -72,6 +74,11 @@ parameters:
       The HawkScan container to download. Change this only if recommended by StackHawk Support.
     type: string
     default: stackhawk/hawkscan:latest
+  resource-class:
+    description: >
+      Override the default `resource_class` (medium). See https://circleci.com/docs/2.0/configuration-reference/#resourceclass .
+    type: string
+    default: medium
 
 environment:
   REPO_DIR: /home/zap/hawk


### PR DESCRIPTION
Added a `resource-class` parameter to the `hawkscan-remote` orb job. This parameter allows end users to adjust the docker container `resource_class` from the default `medium` to any of the [allowed options](https://circleci.com/docs/2.0/configuration-reference/#resourceclass).

> Description here
<!-- please share a quality (SFW) gif or photo -->
<!-- before-and-after UI picks are a good addition as well -->
![image](https://user-images.githubusercontent.com/2282487/149589902-375a2058-78fc-4382-b734-ca3285fba660.png)

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [x] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> 3935

## Checklists

### Development

- [x] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [x] All tests related to the changed code pass in development

### Code review

- [x]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request
