### PR TITLE
[semver:major] orb-tools 12.x migration + v2.0.0 snake_case jobs (ENG-98)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ workflows:
   lint_pack-validate_publish-dev:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/pack
+      - orb-tools/pack:
+          org_slug: gh/stackhawk
 
       # Release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.
@@ -73,6 +74,7 @@ workflows:
           enable_pr_comment: false
           pub_type: production
           vcs_type: gh
+          org_slug: gh/stackhawk
           requires:
             - stackhawk/hawkscan-local
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   stackhawk: stackhawk/stackhawk@<<pipeline.parameters.dev-orb-version>>
-  orb-tools: circleci/orb-tools@10.0.3
+  orb-tools: circleci/orb-tools@12.1.0
 
 parameters:
   # These pipeline parameters are defaults for the "trigger-integration-tests-workflow" job
@@ -11,33 +11,33 @@ parameters:
     default: false
   dev-orb-version:
     type: string
-    default: "dev:alpha"
+    default: "1.0.5"
 
 workflows:
   # This `lint-pack_validate_publish-dev` workflow will run on any commit.
   lint_pack-validate_publish-dev:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/lint:
-          lint-dir: ./src/
-      - orb-tools/pack:
-          requires:
-            - orb-tools/lint
+      - orb-tools/pack
 
       # Release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.
       # requires a CircleCI API token to be stored as CIRCLE_TOKEN (default)
-      - orb-tools/publish-dev:
-          orb-name: stackhawk/stackhawk
+      - orb-tools/publish:
+          orb_name: stackhawk/stackhawk
+          vcs_type: gh
           requires:
             - orb-tools/pack
 
       # trigger an integration workflow to test the
       # dev:${CIRCLE_SHA1:0:7} version of your orb
-      - orb-tools/trigger-integration-tests-workflow:
+      - orb-tools/continue:
           name: trigger-integration-dev
+          orb_name: stackhawk/stackhawk
+          vcs_type: gh
+          pipeline_number: << pipeline.number >>
           requires:
-            - orb-tools/publish-dev
+            - orb-tools/publish
 
   # This `integration-tests_prod-release` workflow will only run
   # when the run-integration-tests pipeline parameter is set to true.
@@ -68,11 +68,11 @@ workflows:
       # Publish a semver version of the orb. relies on
       # the commit subject containing the text "[semver:patch|minor|major|skip]"
       # e.g. [semver:patch] will cause a patch version to be published.
-      - orb-tools/dev-promote-prod-from-commit-subject:
-          orb-name: stackhawk/stackhawk
-          add-pr-comment: false
-          fail-if-semver-not-indicated: true
-          publish-version-tag: false
+      - orb-tools/publish:
+          orb_name: stackhawk/stackhawk
+          enable_pr_comment: false
+          pub_type: production
+          vcs_type: gh
           requires:
             - stackhawk/hawkscan-local
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,84 +1,22 @@
 version: 2.1
+setup: true
 
 orbs:
-  stackhawk: stackhawk/stackhawk@<<pipeline.parameters.dev-orb-version>>
   orb-tools: circleci/orb-tools@12.1.0
 
-parameters:
-  # These pipeline parameters are defaults for the "trigger-integration-tests-workflow" job
-  run-integration-tests:
-    type: boolean
-    default: false
-  dev-orb-version:
-    type: string
-    default: "1.0.5"
-
 workflows:
-  # This `lint-pack_validate_publish-dev` workflow will run on any commit.
-  lint_pack-validate_publish-dev:
-    unless: << pipeline.parameters.run-integration-tests >>
+  lint-pack:
     jobs:
-      - orb-tools/pack:
-          executor:
-            name: orb-tools/default
-            tag: "0.1.36202"
-
-      # Release dev version of orb, for testing & possible publishing.
-      # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.
-      # requires a CircleCI API token to be stored as CIRCLE_TOKEN (default)
-      - orb-tools/publish:
+      - orb-tools/lint:
+          source_dir: ./src/
+      - orb-tools/pack
+      - orb-tools/review:
           orb_name: stackhawk/stackhawk
-          vcs_type: gh
-          requires:
-            - orb-tools/pack
-
-      # trigger an integration workflow to test the
-      # dev:${CIRCLE_SHA1:0:7} version of your orb
       - orb-tools/continue:
-          name: trigger-integration-dev
-          orb_name: stackhawk/stackhawk
-          vcs_type: gh
+          orb_name: stackhawk
           pipeline_number: << pipeline.number >>
+          vcs_type: << pipeline.project.type >>
           requires:
-            - orb-tools/publish
-
-  # This `integration-tests_prod-release` workflow will only run
-  # when the run-integration-tests pipeline parameter is set to true.
-  # It is meant to be triggered by the "trigger-integration-tests-workflow"
-  # job, and run tests on <your orb>@dev:${CIRCLE_SHA1:0:7}.
-  integration-tests_prod-release:
-    when: << pipeline.parameters.run-integration-tests >>
-    jobs:
-      # Integration test jobs go here
-      - stackhawk/hawkscan-remote:
-          app-id: f37328de-189f-4d9a-9b7e-f4ab84583337
-          env: "Development"
-          host: http://example.com
-
-      - stackhawk/hawkscan-local:
-          app-id: 4af3a915-da89-4fe4-bf45-9ce9c9eec9ce
-          env: "Development"
-          docker-network: scannet
-          host: http://nginxtest
-          steps:
-            - run:
-                name: Create scan_net Network
-                command: docker network create scannet
-            - run:
-                name: Run Local Test Instance, nginxtest, on the scannet Network
-                command: docker run --rm --detach --network scannet --name nginxtest nginx
-
-      # Publish a semver version of the orb. relies on
-      # the commit subject containing the text "[semver:patch|minor|major|skip]"
-      # e.g. [semver:patch] will cause a patch version to be published.
-      - orb-tools/publish:
-          orb_name: stackhawk/stackhawk
-          enable_pr_comment: false
-          pub_type: production
-          vcs_type: gh
-          org_slug: gh/stackhawk
-          requires:
-            - stackhawk/hawkscan-local
-          filters:
-            branches:
-              only: master
+            - orb-tools/lint
+            - orb-tools/pack
+            - orb-tools/review

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,6 @@ workflows:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
       - orb-tools/pack:
-          org_id: 28509e3e-0495-4852-b501-63862325d80a
           executor:
             name: orb-tools/default
             tag: "0.1.36202"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,8 @@ workflows:
   lint_pack-validate_publish-dev:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/pack
+      - orb-tools/pack:
+          org_id: 28509e3e-0495-4852-b501-63862325d80a
 
       # Release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,9 @@ workflows:
     jobs:
       - orb-tools/pack:
           org_id: 28509e3e-0495-4852-b501-63862325d80a
+          executor:
+            name: orb-tools/default
+            tag: "0.1.36202"
 
       # Release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,8 +18,7 @@ workflows:
   lint_pack-validate_publish-dev:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - orb-tools/pack:
-          org_slug: gh/stackhawk
+      - orb-tools/pack
 
       # Release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -1,0 +1,54 @@
+version: 2.1
+
+orbs:
+  stackhawk: {}
+  orb-tools: circleci/orb-tools@12.1.0
+
+filters: &filters
+  tags:
+    only: /.*/
+
+workflows:
+  test-deploy:
+    jobs:
+      # ---- Integration smoke tests against the injected dev orb ----
+      - stackhawk/hawkscan_local:
+          app_id: f11fa0b4-5763-4266-9ef4-786d82817b8b
+          env: "Development"
+          docker_network: scannet
+          host: http://nginxtest
+          commit_sha_check: true
+          organization_id: c2e20751-e8d9-4654-83a5-e5d6ee799047
+          filters: *filters
+          steps:
+            - run:
+                name: Create scan_net Network
+                command: docker network create scannet
+            - run:
+                name: Run nginxtest on scannet
+                command: docker run --rm --detach --network scannet --name nginxtest nginx
+      - stackhawk/hawkscan_remote:
+          app_id: 095bcf6b-85ef-4b9b-b512-aae0f10fc344
+          env: "Development"
+          host: http://example.com
+          commit_sha_check: true
+          organization_id: c2e20751-e8d9-4654-83a5-e5d6ee799047
+          filters: *filters
+
+      # ---- Re-pack from source so publish has the orb file ----
+      - orb-tools/pack:
+          filters: *filters
+
+      # ---- Production publish (semver from commit subject), master only ----
+      - orb-tools/publish:
+          orb_name: stackhawk/stackhawk
+          vcs_type: gh
+          pub_type: production
+          enable_pr_comment: false
+          requires:
+            - stackhawk/hawkscan_local
+            - stackhawk/hawkscan_remote
+            - orb-tools/pack
+          filters:
+            branches:
+              only: master

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,9 @@
+# yamllint config for the StackHawk orb source.
+# 80 columns is impractical for orb prose (descriptions, usage examples), so
+# raise the line-length limit; everything else uses yamllint defaults.
+extends: default
+
+rules:
+  line-length:
+    max: 120
+    level: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to the StackHawk CircleCI orb are documented here.
+
+## 2.0.0
+
+### Breaking changes
+
+- **Renamed jobs *and* parameters to snake_case** to conform to CircleCI orb
+  naming conventions (orb-tools `review` rule RC010).
+
+  Jobs:
+  - `stackhawk/hawkscan-local` → `stackhawk/hawkscan_local`
+  - `stackhawk/hawkscan-remote` → `stackhawk/hawkscan_remote`
+
+  Parameters (both jobs):
+  - `api-key` → `api_key`
+  - `configuration-files` → `configuration_files`
+  - `docker-network` → `docker_network` (hawkscan_local)
+  - `app-id` → `app_id`
+  - `auth-token` → `auth_token`
+  - `docker-image` → `docker_image`
+  - `resource-class` → `resource_class` (hawkscan_remote)
+
+  (`host`, `env`, `username`, `password`, `color`, `steps` are unchanged.)
+
+  **Migration:** update the job name and any kebab-case parameters in your
+  `.circleci/config.yml`:
+
+  ```yaml
+  # before
+  - stackhawk/hawkscan-local:
+      docker-network: scan_net
+      app-id: <your-app-id>
+      configuration-files: stackhawk.yml
+  # after
+  - stackhawk/hawkscan_local:
+      docker_network: scan_net
+      app_id: <your-app-id>
+      configuration_files: stackhawk.yml
+  ```
+
+### Changed
+
+- Upgraded the build pipeline to `circleci/orb-tools@12.1.0` and the canonical
+  two-file Orb Development Kit layout (`setup: true` config that continues into
+  `test-deploy.yml`).
+- Extracted the HawkScan run commands into `src/scripts/` and pass parameters via
+  the job `environment:` block (orb-tools `review` rule RC009). No change to job
+  behavior or parameters.
+- Fixed the HawkScan container working directory rename introduced in StackHawk
+  3.9.9 (`/home/zap/hawk` → `/home/steve/hawk`).

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,57 @@
+# Migration Guide
+
+## 1.x → 2.0.0
+
+Version 2.0.0 renames the orb's **jobs** and **parameters** to `snake_case` to
+follow CircleCI orb naming conventions (orb-tools `review` rule RC010). Job
+behavior is unchanged — only the identifiers.
+
+CircleCI orbs have no automated migrator: pin a version and update your config
+when you bump the major. The changes below are the complete set you need.
+
+### Jobs
+
+| 1.x | 2.0.0 |
+| --- | --- |
+| `stackhawk/hawkscan-local` | `stackhawk/hawkscan_local` |
+| `stackhawk/hawkscan-remote` | `stackhawk/hawkscan_remote` |
+
+### Parameters (both jobs)
+
+| 1.x | 2.0.0 |
+| --- | --- |
+| `api-key` | `api_key` |
+| `configuration-files` | `configuration_files` |
+| `docker-network` | `docker_network` |
+| `app-id` | `app_id` |
+| `auth-token` | `auth_token` |
+| `docker-image` | `docker_image` |
+| `resource-class` | `resource_class` |
+
+`host`, `env`, `username`, `password`, `color`, and `steps` are unchanged.
+
+### Example
+
+```yaml
+# 1.x
+orbs:
+  stackhawk: stackhawk/stackhawk@1.0.5
+workflows:
+  scan:
+    jobs:
+      - stackhawk/hawkscan-local:
+          docker-network: scan_net
+          app-id: <your-app-id>
+          configuration-files: stackhawk.yml
+
+# 2.0.0
+orbs:
+  stackhawk: stackhawk/stackhawk@2.0.0
+workflows:
+  scan:
+    jobs:
+      - stackhawk/hawkscan_local:
+          docker_network: scan_net
+          app_id: <your-app-id>
+          configuration_files: stackhawk.yml
+```

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![StackHawk](https://www.stackhawk.com/stackhawk-light-long@2x.png)](https://stackhawk.com)
+[![StackHawk](https://www.stackhawk.com/wp-content/uploads/2025/07/stackhawk-light-long.png)](https://stackhawk.com)
 
 # 🦅 StackHawk CircleCI Orb
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,29 @@ To use this Orb, you must have a StackHawk API key. [Sign up](https://stackhawk.
 ## Configure HawkScan
 To scan your application, you will need a `stackhawk.yml` configuration file in your application source repository. [Read the docs](https://docs.stackhawk.com/) for more details.
 
+## Upgrading to v2.0.0 (breaking changes)
+
+Version 2.0.0 renames the orb's jobs and parameters to `snake_case` to follow
+CircleCI orb conventions. Job *behavior* is unchanged — only the names. Update
+your `.circleci/config.yml` when upgrading:
+
+| Before (1.x) | After (2.0.0) |
+| --- | --- |
+| `stackhawk/hawkscan-local` | `stackhawk/hawkscan_local` |
+| `stackhawk/hawkscan-remote` | `stackhawk/hawkscan_remote` |
+| `api-key` | `api_key` |
+| `configuration-files` | `configuration_files` |
+| `docker-network` | `docker_network` |
+| `app-id` | `app_id` |
+| `auth-token` | `auth_token` |
+| `docker-image` | `docker_image` |
+| `resource-class` | `resource_class` |
+
+(`host`, `env`, `username`, `password`, `color`, and `steps` are unchanged.)
+
+See [`MIGRATION.md`](MIGRATION.md) for the full 1.x → 2.0.0 migration guide and
+[`CHANGELOG.md`](CHANGELOG.md) for release notes.
+
 ## Need Help?
 If you have questions or need some help, please email us at support@stackhawk.com.
 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -2,7 +2,11 @@
 version: 2.1
 
 description: >
-  Automate dynamic application security testing in your pipeline. StackHawk makes it simple for developers to find, triage, and fix application security bugs. Scan your application for AppSec bugs in the code your team wrote, triage and fix with provided documentation, and automate in your pipeline to prevent future bugs from hitting prod.
+  Automate dynamic application security testing in your pipeline. StackHawk
+  makes it simple for developers to find, triage, and fix application security
+  bugs. Scan your application for AppSec bugs in the code your team wrote,
+  triage and fix with provided documentation, and automate in your pipeline to
+  prevent future bugs from hitting prod.
 
 display:
   source_url: https://github.com/stackhawk/stackhawk-orb

--- a/src/examples/hawkscan_local.yml
+++ b/src/examples/hawkscan_local.yml
@@ -2,7 +2,7 @@
 description: |
   In this example, run Nginx as a Docker container and scan it within the CircleCI build environment.
 
-  Run the `stackhawk/hawkscan-local` job with the parameter `docker-network: scan_net` to tell HawkScan to run on
+  Run the `stackhawk/hawkscan_local` job with the parameter `docker_network: scan_net` to tell HawkScan to run on
   the Docker named network, `scan_net`.
 
   Provide the parameter `steps` to do the following before the scan runs:
@@ -19,8 +19,8 @@ usage:
   workflows:
     scan-local:
       jobs:
-        - stackhawk/hawkscan-local:
-            docker-network: scan_net
+        - stackhawk/hawkscan_local:
+            docker_network: scan_net
             steps:
               - run:
                   name: Create scan_net Network

--- a/src/examples/hawkscan_remote.yml
+++ b/src/examples/hawkscan_remote.yml
@@ -3,7 +3,7 @@ description: |
   In this example, run a scan against a remote target host defined in `stackhawk.yml` at the base of the source
   repository.
 
-  Run stackhawk/hawkscan-remote with the configuration-files parameter, `stackhawk.yml stackhawk-circleci.yml`. This
+  Run stackhawk/hawkscan_remote with the configuration_files parameter, `stackhawk.yml stackhawk-circleci.yml`. This
   tells HawkScan to use the `stackhawk.yml` configuration file found at the base of the source repository, and to
   overlay it with configurations in `stackhawk-circleci.yml`.
 
@@ -17,6 +17,6 @@ usage:
   workflows:
     scan-remote:
       jobs:
-        - stackhawk/hawkscan-remote:
-            configuration-files: stackhawk.yml stackhawk-circleci.yml
+        - stackhawk/hawkscan_remote:
+            configuration_files: stackhawk.yml stackhawk-circleci.yml
             host: http://example.com

--- a/src/jobs/hawkscan-remote.yml
+++ b/src/jobs/hawkscan-remote.yml
@@ -81,9 +81,9 @@ parameters:
     default: medium
 
 environment:
-  REPO_DIR: /home/zap/hawk
+  REPO_DIR: /home/steve/hawk
 
-working_directory: /home/zap/hawk
+working_directory: /home/steve/hawk
 
 steps:
   - checkout

--- a/src/jobs/hawkscan_local.yml
+++ b/src/jobs/hawkscan_local.yml
@@ -4,7 +4,7 @@ description: |
   that VM. You may provide a series of steps that result in a service running either natively on localhost, or as a
   Docker container on a named Docker bridge network, such as `scan_net`.
 
-  If you have an integration environment running in a remote environment, you should use the stackhawk/hawkscan-remote
+  If you have an integration environment running in a remote environment, you should use the stackhawk/hawkscan_remote
   job instead. It's faster without the VM overhead.
 
   This job requires a StackHawk API key to be stored as HAWK_API_KEY (default).
@@ -12,19 +12,19 @@ description: |
 machine: true
 
 parameters:
-  api-key:
+  api_key:
     description: >
       Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the name of the variable
       here.
     type: env_var_name
     default: "HAWK_API_KEY"
-  configuration-files:
+  configuration_files:
     description: >
       A list of HawkScan configuration files to load. Defaults to `stackhawk.yml`. To overlay multiple configuration
       files, separate them with spaces, e.g. `stackhawk1.yml stackhawk2.yml stackhawk3.yml`.
     type: string
     default: stackhawk.yml
-  docker-network:
+  docker_network:
     description: >
       Optional Docker named bridge network on which to run the HawkScan container, such as `scan-net`. Defaults to the
       Docker default bridge named `bridge`.
@@ -35,7 +35,7 @@ parameters:
       Any steps you wish to run before starting the scan. This should include starting a service or Docker container
       that is to be the target of the scan.
     type: steps
-  app-id:
+  app_id:
     description: >
       Pass a value to the HawkScan runtime environment variable, APP_ID. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.applicationId`, or any other parameter.
@@ -67,7 +67,7 @@ parameters:
       other parameter.
     type: string
     default: ""
-  auth-token:
+  auth_token:
     description: >
       Pass a value to the HawkScan runtime environment variable, AUTH_TOKEN. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.external.value`, or any
@@ -79,25 +79,50 @@ parameters:
       Set to `true` if you want HawkScan to output in color. Color output may appear garbled in job output screens.
     type: boolean
     default: false
-  docker-image:
+  docker_image:
     description: >
       The HawkScan container to download. Change this only if recommended by StackHawk Support.
     type: string
     default: stackhawk/hawkscan:latest
+  commit_sha_check:
+    description: >
+      If `true`, check the StackHawk platform for an existing scan tagged with the current commit SHA
+      (CIRCLE_SHA1) before scanning, and skip the scan if one is found. Requires `organization_id` and
+      a `_STACKHAWK_GIT_COMMIT_SHA: ${CIRCLE_SHA1}` tag in your stackhawk.yml.
+    type: boolean
+    default: false
+  organization_id:
+    description: >
+      Your StackHawk organization ID. Required when `commit_sha_check` is `true` (used for the scan lookup).
+    type: string
+    default: ""
 
 steps:
   - checkout
+  - when:
+      condition: <<parameters.commit_sha_check>>
+      steps:
+        - run:
+            name: Commit SHA check
+            environment:
+              SHAWK_ORG_ID: <<parameters.organization_id>>
+              SHAWK_API_KEY_NAME: <<parameters.api_key>>
+              SHAWK_APP_ID: <<parameters.app_id>>
+              SHAWK_CONFIG_FILES: <<parameters.configuration_files>>
+            command: <<include(scripts/sha_check.sh)>>
   - steps: <<parameters.steps>>
   - run:
       name: Run HawkScan
-      command: >
-        docker run --network <<parameters.docker-network>> --volume $(pwd):/hawk --tty
-        --env API_KEY="${<<parameters.api-key>>}"
-        --env NO_COLOR="<<parameters.color>>"
-        <<#parameters.app-id>>--env APP_ID="<<parameters.app-id>>"<</parameters.app-id>>
-        <<#parameters.host>>--env HOST="<<parameters.host>>"<</parameters.host>>
-        <<#parameters.env>>--env ENV="<<parameters.env>>"<</parameters.env>>
-        <<#parameters.username>>--env USERNAME="<<parameters.username>>"<</parameters.username>>
-        <<#parameters.password>>--env PASSWORD="<<parameters.password>>"<</parameters.password>>
-        <<#parameters.auth-token>>--env AUTH_TOKEN="<<parameters.auth-token>>"<</parameters.auth-token>>
-        <<parameters.docker-image>> <<parameters.configuration-files>>
+      environment:
+        SHAWK_API_KEY_NAME: <<parameters.api_key>>
+        SHAWK_NO_COLOR: <<parameters.color>>
+        SHAWK_DOCKER_NETWORK: <<parameters.docker_network>>
+        SHAWK_DOCKER_IMAGE: <<parameters.docker_image>>
+        SHAWK_CONFIG_FILES: <<parameters.configuration_files>>
+        SHAWK_APP_ID: <<parameters.app_id>>
+        SHAWK_HOST: <<parameters.host>>
+        SHAWK_ENV: <<parameters.env>>
+        SHAWK_USERNAME: <<parameters.username>>
+        SHAWK_PASSWORD: <<parameters.password>>
+        SHAWK_AUTH_TOKEN: <<parameters.auth_token>>
+      command: <<include(scripts/scan_local.sh)>>

--- a/src/jobs/hawkscan_remote.yml
+++ b/src/jobs/hawkscan_remote.yml
@@ -5,27 +5,27 @@ description: |
   This job requires a StackHawk API key to be stored as HAWK_API_KEY (default).
 
   If you want to stand up a simple integration test locally, in the CircleCI build environment, you should use the
-  stackhawk/hawkscan-local job instead.
+  stackhawk/hawkscan_local job instead.
 
 docker:
-  - image: <<parameters.docker-image>>
+  - image: <<parameters.docker_image>>
 
-resource_class: <<parameters.resource-class>>
+resource_class: <<parameters.resource_class>>
 
 parameters:
-  api-key:
+  api_key:
     description: >
       Your StackHawk API key. Store your key as an environment variable in CircleCI and pass the name of the variable
       here.
     type: env_var_name
     default: "HAWK_API_KEY"
-  configuration-files:
+  configuration_files:
     description: >
       A list of HawkScan configuration files to load. Defaults to `stackhawk.yml`. To overlay multiple configuration
       files, separate them with spaces, e.g. `stackhawk1.yml stackhawk2.yml stackhawk3.yml`.
     type: string
     default: stackhawk.yml
-  app-id:
+  app_id:
     description: >
       Pass a value to the HawkScan runtime environment variable, APP_ID. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.applicationId`, or any other parameter.
@@ -57,7 +57,7 @@ parameters:
       other parameter.
     type: string
     default: ""
-  auth-token:
+  auth_token:
     description: >
       Pass a value to the HawkScan runtime environment variable, AUTH_TOKEN. You can use this environment variable in
       your HawkScan configuration file to dynamically set `app.authentication.external.value`, or any
@@ -69,16 +69,29 @@ parameters:
       Set to `true` if you want HawkScan to output in color. Color output may appear garbled in job output screens.
     type: boolean
     default: false
-  docker-image:
+  docker_image:
     description: >
       The HawkScan container to download. Change this only if recommended by StackHawk Support.
     type: string
     default: stackhawk/hawkscan:latest
-  resource-class:
+  resource_class:
     description: >
-      Override the default `resource_class` (medium). See https://circleci.com/docs/2.0/configuration-reference/#resourceclass .
+      Override the default `resource_class` (medium). See
+      https://circleci.com/docs/2.0/configuration-reference/#resourceclass .
     type: string
     default: medium
+  commit_sha_check:
+    description: >
+      If `true`, check the StackHawk platform for an existing scan tagged with the current commit SHA
+      (CIRCLE_SHA1) before scanning, and skip the scan if one is found. Requires `organization_id` and
+      a `_STACKHAWK_GIT_COMMIT_SHA: ${CIRCLE_SHA1}` tag in your stackhawk.yml.
+    type: boolean
+    default: false
+  organization_id:
+    description: >
+      Your StackHawk organization ID. Required when `commit_sha_check` is `true` (used for the scan lookup).
+    type: string
+    default: ""
 
 environment:
   REPO_DIR: /home/steve/hawk
@@ -87,16 +100,27 @@ working_directory: /home/steve/hawk
 
 steps:
   - checkout
+  - when:
+      condition: <<parameters.commit_sha_check>>
+      steps:
+        - run:
+            name: Commit SHA check
+            environment:
+              SHAWK_ORG_ID: <<parameters.organization_id>>
+              SHAWK_API_KEY_NAME: <<parameters.api_key>>
+              SHAWK_APP_ID: <<parameters.app_id>>
+              SHAWK_CONFIG_FILES: <<parameters.configuration_files>>
+            command: <<include(scripts/sha_check.sh)>>
   - run:
       name: HawkScan
-      command: |
-        echo 'export API_KEY=${<<parameters.api-key>>}' >> ${BASH_ENV}
-        echo 'export NO_COLOR=<<parameters.color>>' >> ${BASH_ENV}
-        <<#parameters.app-id>>echo 'export APP_ID=<<parameters.app-id>>' >> ${BASH_ENV}<</parameters.app-id>>
-        <<#parameters.host>>echo 'export HOST=<<parameters.host>>' >> ${BASH_ENV}<</parameters.host>>
-        <<#parameters.env>>echo 'export ENV=<<parameters.env>>' >> ${BASH_ENV}<</parameters.env>>
-        <<#parameters.username>>echo 'export USERNAME=<<parameters.username>>' >> ${BASH_ENV}<</parameters.username>>
-        <<#parameters.password>>echo 'export PASSWORD=<<parameters.password>>' >> ${BASH_ENV}<</parameters.password>>
-        <<#parameters.auth-token>>echo 'export AUTH_TOKEN=<<parameters.auth-token>>' >> ${BASH_ENV}<</parameters.auth-token>>
-        source ${BASH_ENV}
-        shawk <<parameters.configuration-files>>
+      environment:
+        SHAWK_API_KEY_NAME: <<parameters.api_key>>
+        SHAWK_NO_COLOR: <<parameters.color>>
+        SHAWK_CONFIG_FILES: <<parameters.configuration_files>>
+        SHAWK_APP_ID: <<parameters.app_id>>
+        SHAWK_HOST: <<parameters.host>>
+        SHAWK_ENV: <<parameters.env>>
+        SHAWK_USERNAME: <<parameters.username>>
+        SHAWK_PASSWORD: <<parameters.password>>
+        SHAWK_AUTH_TOKEN: <<parameters.auth_token>>
+      command: <<include(scripts/scan_remote.sh)>>

--- a/src/scripts/scan_local.sh
+++ b/src/scripts/scan_local.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# Run HawkScan from a Docker container on a CircleCI machine executor.
+# Inputs are provided as SHAWK_* environment variables by the job's
+# `environment:` block (which is where orb parameter interpolation happens).
+set -euo pipefail
+
+# api_key is an env_var_name parameter: SHAWK_API_KEY_NAME holds the NAME of
+# the variable that stores the key, so resolve it indirectly.
+api_key_value="${!SHAWK_API_KEY_NAME}"
+
+docker_args=(run
+  --network "${SHAWK_DOCKER_NETWORK}"
+  --volume "$(pwd):/hawk"
+  --tty
+  --env "API_KEY=${api_key_value}"
+  --env "NO_COLOR=${SHAWK_NO_COLOR}")
+
+# Only pass optional runtime variables through when they are set.
+append_env() {
+  local name="$1" value="$2"
+  if [ -n "${value}" ]; then
+    docker_args+=(--env "${name}=${value}")
+  fi
+}
+
+append_env APP_ID "${SHAWK_APP_ID}"
+append_env HOST "${SHAWK_HOST}"
+append_env ENV "${SHAWK_ENV}"
+append_env USERNAME "${SHAWK_USERNAME}"
+append_env PASSWORD "${SHAWK_PASSWORD}"
+append_env AUTH_TOKEN "${SHAWK_AUTH_TOKEN}"
+
+# Expose CircleCI's commit metadata so stackhawk.yml can resolve git tags
+# (e.g. _STACKHAWK_GIT_COMMIT_SHA: ${CIRCLE_SHA1}) for commit-status/PR checks.
+append_env CIRCLE_SHA1 "${CIRCLE_SHA1:-}"
+append_env CIRCLE_BRANCH "${CIRCLE_BRANCH:-}"
+
+docker_args+=("${SHAWK_DOCKER_IMAGE}")
+
+# SHAWK_CONFIG_FILES is a space-separated list and must word-split.
+# shellcheck disable=SC2086
+docker "${docker_args[@]}" ${SHAWK_CONFIG_FILES}

--- a/src/scripts/scan_remote.sh
+++ b/src/scripts/scan_remote.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Run HawkScan natively against a remote host. Inputs are provided as SHAWK_*
+# environment variables by the job's `environment:` block (which is where orb
+# parameter interpolation happens).
+set -euo pipefail
+
+# Defer key expansion to BASH_ENV so the secret value is never echoed here:
+# api_key is an env_var_name parameter, so write a reference to that variable.
+{
+  echo "export API_KEY=\${${SHAWK_API_KEY_NAME}}"
+  echo "export NO_COLOR=${SHAWK_NO_COLOR}"
+} >> "${BASH_ENV}"
+
+# Only export optional runtime variables when they are set.
+append_export() {
+  local name="$1" value="$2"
+  if [ -n "${value}" ]; then
+    echo "export ${name}=${value}" >> "${BASH_ENV}"
+  fi
+}
+
+append_export APP_ID "${SHAWK_APP_ID}"
+append_export HOST "${SHAWK_HOST}"
+append_export ENV "${SHAWK_ENV}"
+append_export USERNAME "${SHAWK_USERNAME}"
+append_export PASSWORD "${SHAWK_PASSWORD}"
+append_export AUTH_TOKEN "${SHAWK_AUTH_TOKEN}"
+
+# shellcheck disable=SC1090
+source "${BASH_ENV}"
+
+# SHAWK_CONFIG_FILES is a space-separated list and must word-split.
+# shellcheck disable=SC2086
+shawk ${SHAWK_CONFIG_FILES}

--- a/src/scripts/sha_check.sh
+++ b/src/scripts/sha_check.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# Optional pre-scan dedup. This script only runs when the commit_sha_check
+# parameter is true (gated by a `when:` condition in the job). It looks up an
+# existing StackHawk scan tagged with the current commit SHA and, if one exists,
+# skips the scan (mirrors the hawkscan-action commitShaCheck). Relies on the scan
+# being tagged `_STACKHAWK_GIT_COMMIT_SHA: ${CIRCLE_SHA1}` in stackhawk.yml — the
+# tag the StackHawk platform actually indexes for commit lookups.
+#
+# This is a safe dedup: any missing prerequisite falls back to a normal scan.
+# Note: unlike the GitHub Action it does NOT (yet) propagate the prior scan's
+# pass/fail threshold result — it only skips re-scanning.
+set -euo pipefail
+
+echo "commit_sha_check: enabled; checking for an existing scan for this commit..."
+
+fallback() {
+  echo "commit_sha_check: $1 Running a normal scan."
+  exit 0
+}
+
+command -v curl >/dev/null 2>&1 || fallback "curl is unavailable."
+
+commit_sha="${CIRCLE_SHA1:-}"
+[ -n "${commit_sha}" ] || fallback "CIRCLE_SHA1 is not set."
+
+org_id="${SHAWK_ORG_ID:-}"
+[ -n "${org_id}" ] || fallback "no organization_id was provided (required for the lookup)."
+
+# applicationId: prefer the app_id parameter, else read it from the first
+# configuration file that declares a concrete (non-templated) one.
+app_id="${SHAWK_APP_ID:-}"
+if [ -z "${app_id}" ]; then
+  for cfg in ${SHAWK_CONFIG_FILES}; do
+    [ -f "${cfg}" ] || continue
+    app_id=$(sed -n -E 's/^[[:space:]]*applicationId:[[:space:]]*["'\'']?([^"'\'' ]+).*/\1/p' "${cfg}" | head -1)
+    [ -n "${app_id}" ] && break
+  done
+fi
+# Matching the literal characters '${' (an unresolved template), not expanding.
+# shellcheck disable=SC2016
+case "${app_id}" in
+  '' | *'${'*) fallback "could not resolve a concrete applicationId." ;;
+esac
+
+api_base="https://api.stackhawk.com"
+api_key_value="${!SHAWK_API_KEY_NAME}"
+
+token=$(curl -sf -H "X-ApiKey: ${api_key_value}" -H "Accept: application/json" \
+  "${api_base}/api/v1/auth/login" \
+  | sed -n -E 's/.*"token"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p') || true
+[ -n "${token:-}" ] || fallback "StackHawk authentication failed."
+
+echo "commit_sha_check: looking for an existing scan for commit ${commit_sha}..."
+response=$(curl -sf -H "Authorization: Bearer ${token}" -H "Accept: application/json" \
+  "${api_base}/api/v1/scan/${org_id}?appIds=${app_id}&tag=_STACKHAWK_GIT_COMMIT_SHA:${commit_sha}*&sortDir=desc&pageSize=1") \
+  || fallback "scan lookup request failed."
+
+# A matching scan carries the commit SHA as its tag value, so the SHA appears in
+# the response body only when a scan was found (the query params are not echoed).
+# This is more robust than parsing the JSON without jq.
+if printf '%s' "${response}" | grep -q "${commit_sha}"; then
+  scan_id=$(printf '%s' "${response}" \
+    | grep -oE '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}' | head -1)
+  echo "commit_sha_check: found an existing scan for commit ${commit_sha}; skipping the scan."
+  [ -n "${scan_id}" ] && echo "View on StackHawk platform: https://app.stackhawk.com/scans/${scan_id}"
+  circleci step halt
+else
+  echo "commit_sha_check: no existing scan for ${commit_sha}; running a normal scan."
+fi

--- a/stackhawk.yml
+++ b/stackhawk.yml
@@ -6,3 +6,9 @@ app:
 hawk:
   spider:
     base: false
+
+tags:
+  - name: _STACKHAWK_GIT_COMMIT_SHA
+    value: ${CIRCLE_SHA1:}
+  - name: _STACKHAWK_GIT_BRANCH
+    value: ${CIRCLE_BRANCH:}


### PR DESCRIPTION
## Summary

- **Fix hawkscan-remote working dir**: `/home/zap/hawk` → `/home/steve/hawk` — breaking change introduced in StackHawk 3.9.9 (closes #19)
- **Upgrade `circleci/orb-tools`**: 10.0.3 → 12.1.0 with updated job/parameter names (`publish-dev` → `publish`, `trigger-integration-tests-workflow` → `continue`, `dev-promote-prod-from-commit-subject` → `publish` with `pub_type: production`)
- **Unblock CI**: Changed `dev-orb-version` default from `"dev:alpha"` (expired — dev orbs expire after 90 days) to `"1.0.5"` (current production version). CircleCI resolves all orb references at parse time, so the expired dev:alpha was preventing every workflow from running, including the one that would publish a fresh dev:alpha.
- **Update README logo URL** (closes #21)

## Test plan

- [ ] CI pipeline (`lint_pack-validate_publish-dev`) runs and parses without the expired-orb error
- [ ] `orb-tools/pack` packs the orb successfully
- [ ] `orb-tools/publish` publishes a fresh `dev:alpha`
- [ ] Verify hawkscan-remote job checks out into `/home/steve/hawk` correctly