### PR TITLE
fix: tag-driven orb publish + GitHub-driven Release workflow (ENG-98)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,18 +4,28 @@ setup: true
 orbs:
   orb-tools: circleci/orb-tools@12.1.0
 
+# Run the setup pipeline on branch pushes AND on version tags, so that pushing a
+# vX.Y.Z tag flows through continue into the test-deploy production publish.
+filters: &filters
+  tags:
+    only: /.*/
+
 workflows:
   lint-pack:
     jobs:
       - orb-tools/lint:
           source_dir: ./src/
-      - orb-tools/pack
+          filters: *filters
+      - orb-tools/pack:
+          filters: *filters
       - orb-tools/review:
           orb_name: stackhawk/stackhawk
+          filters: *filters
       - orb-tools/continue:
           orb_name: stackhawk
           pipeline_number: << pipeline.number >>
           vcs_type: << pipeline.project.type >>
+          filters: *filters
           requires:
             - orb-tools/lint
             - orb-tools/pack

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -39,7 +39,9 @@ workflows:
       - orb-tools/pack:
           filters: *filters
 
-      # ---- Production publish (semver from commit subject), master only ----
+      # ---- Production publish, triggered by pushing a vX.Y.Z tag ----
+      # orb-tools 12.x publishes the version from the git tag, so this runs on
+      # tags only (never on branch pushes). Release by pushing e.g. v2.0.0.
       - orb-tools/publish:
           orb_name: stackhawk/stackhawk
           vcs_type: gh
@@ -51,4 +53,6 @@ workflows:
             - orb-tools/pack
           filters:
             branches:
-              only: master
+              ignore: /.*/
+            tags:
+              only: /^v[0-9]+\.[0-9]+\.[0-9]+$/

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,20 +12,19 @@ circleci orb pack src | circleci orb publish - stackhawk/stackhawk@dev:alpha
 ## Publishing a New Orb Version
 
 This orb uses CircleCI's Orb Development Kit (orb-tools v12), which publishes
-production versions from **git tags** — not from the merge commit message.
+production versions from **git tags**. Releases are driven entirely from GitHub
+via a manual workflow — no special commit messages or local tagging required.
 
 1. Merge your change to `master` (a normal merge is fine). On `master`, CI runs
    lint, pack, review, and the integration scans, but does **not** publish.
-2. To cut a release, push a semantic version tag:
+2. Cut the release from **Actions → "Release Orb" → Run workflow**, entering the
+   semver version (e.g. `2.0.1`, no `v` prefix).
 
-   ```shell
-   git checkout master && git pull
-   git tag v2.0.1        # bump per semver: patch / minor / major
-   git push origin v2.0.1
-   ```
+The workflow creates a GitHub Release and a matching `vX.Y.Z` tag on `master`.
+That tag triggers the CircleCI setup pipeline, which continues into `test-deploy`
+and runs `orb-tools/publish` (production), publishing `stackhawk/stackhawk` at the
+tag's version.
 
-   The tag triggers the setup pipeline, which continues into `test-deploy` and
-   runs `orb-tools/publish` (production), publishing the orb at the tag's version.
-
-> Tags must match `vX.Y.Z` (e.g. `v2.0.1`). The old `[semver:...]` merge-commit
-> convention no longer applies — orb-tools v12 reads the version from the tag.
+> The old `[semver:...]` merge-commit convention no longer applies — orb-tools
+> v12 reads the version from the `vX.Y.Z` tag, and the Release Orb workflow
+> creates that tag for you.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -11,10 +11,21 @@ circleci orb pack src | circleci orb publish - stackhawk/stackhawk@dev:alpha
 
 ## Publishing a New Orb Version
 
-To publish a new version of this orb, open a PR to the `master` branch.
+This orb uses CircleCI's Orb Development Kit (orb-tools v12), which publishes
+production versions from **git tags** — not from the merge commit message.
 
-**IMPORTANT**: When you merge your PR, you must select squash merge and then add a merge commit message with `[semver:<patch|minor|major>]` in the message. The CircleCI workflow will interpret that as a patch, minor, or major release and will update the version accordingly.
+1. Merge your change to `master` (a normal merge is fine). On `master`, CI runs
+   lint, pack, review, and the integration scans, but does **not** publish.
+2. To cut a release, push a semantic version tag:
 
-![squash merge](squashmerge.gif)
+   ```shell
+   git checkout master && git pull
+   git tag v2.0.1        # bump per semver: patch / minor / major
+   git push origin v2.0.1
+   ```
 
-A normal merge will not give you the opportunity to update the merge commit message, which will default to something like "Merge pull request #12 from stackhawk/feature/bump".
+   The tag triggers the setup pipeline, which continues into `test-deploy` and
+   runs `orb-tools/publish` (production), publishing the orb at the tag's version.
+
+> Tags must match `vX.Y.Z` (e.g. `v2.0.1`). The old `[semver:...]` merge-commit
+> convention no longer applies — orb-tools v12 reads the version from the tag.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,60 @@
+# Release the StackHawk Orb.
+#
+# Manual workflow_dispatch: enter a semver version and this creates a GitHub
+# Release and matching `vX.Y.Z` tag on master. Pushing that tag triggers the
+# CircleCI setup pipeline, which continues into test-deploy and runs
+# orb-tools/publish (production) — publishing stackhawk/stackhawk@X.Y.Z.
+#
+# Nothing here publishes the orb directly; the tag drives the CircleCI publish
+# we maintain in .circleci/test-deploy.yml. No special commit messages required.
+name: Release Orb
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release — semver, no 'v' prefix (e.g. 2.0.0)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      # Bind the (semi-trusted) dispatch input to an env var so it is never
+      # interpolated directly into a run: script (avoids command injection).
+      VERSION: ${{ inputs.version }}
+    steps:
+      - name: Validate version
+        run: |
+          if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+            echo "::error::Version must be semver X.Y.Z with no 'v' prefix (got '$VERSION')."
+            exit 1
+          fi
+
+      - name: Checkout master
+        uses: actions/checkout@v4
+        with:
+          ref: master
+          fetch-depth: 0
+
+      - name: Create GitHub Release and tag
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="v${VERSION}"
+          if gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::Release $tag already exists."
+            exit 1
+          fi
+          notes="Published to the orb registry by CircleCI from this tag."
+          notes="${notes} See CHANGELOG.md and MIGRATION.md."
+          gh release create "$tag" \
+            --repo "$GITHUB_REPOSITORY" \
+            --target master \
+            --title "$tag" \
+            --notes "$notes"
+          echo "Created ${tag} — CircleCI will publish stackhawk/stackhawk@${VERSION} from the tag."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,12 +17,16 @@ on:
         required: true
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    # SECURITY: gate the release behind a protected Environment with Required
+    # Reviewers, so a human approves before the tag/release is created. Create it
+    # in Settings -> Environments -> New environment -> "tag-release" -> add
+    # Required Reviewers. (Until configured, the job runs without the gate.)
+    environment: tag-release
+    permissions:
+      contents: write # create the GitHub Release + vX.Y.Z tag
     env:
       # Bind the (semi-trusted) dispatch input to an env var so it is never
       # interpolated directly into a run: script (avoids command injection).


### PR DESCRIPTION
## Summary

Makes the orb actually releasable after the orb-tools 12.x migration, and drives releases entirely from GitHub.

**Problem:** orb-tools 12.x `publish pub_type: production` publishes from a **git tag**, but the migration's publish job was branch-filtered (`only: master`) — so the master merge ran it and failed (`No tag detected`), leaving master's test-deploy red and 1.0.5 still latest.

### Changes
- `.circleci/config.yml`: tag filters so the setup pipeline runs on tag pushes and continues into test-deploy.
- `.circleci/test-deploy.yml`: production publish now runs on **tags only** (`branches: ignore /.*/`, `tags: only /^v#.#.#$/`) — never on branch pushes.
- `.github/workflows/release.yml` (**new**): a manual **`workflow_dispatch`** "Release Orb" job. Enter a semver version → it creates a GitHub Release + `vX.Y.Z` tag on master → the tag triggers the CircleCI publish. No special commit messages or local tagging.
- `CONTRIBUTING.md`: documents the Actions → "Release Orb" flow.

### Release flow (after this merges)
**Actions → "Release Orb" → Run workflow → version `2.0.0`** → tags `v2.0.0` → CircleCI test-deploy → `orb-tools/publish` → `stackhawk/stackhawk@2.0.0` in the registry.

## How does this make you feel?
![ship it](https://media.giphy.com/media/lUDQ6pW8cJuxO/giphy.gif)

## Test plan
- [x] `circleci config validate` (config.yml + test-deploy.yml) pass
- [x] `actionlint` clean on release.yml
- [x] Branch CI green — `test-deploy` passes and `orb-tools/publish` is correctly **skipped** on branch pushes (tags-only)
- [ ] After merge: `Release Orb` workflow appears in Actions (workflow_dispatch shows once on default branch)
- [ ] First release: run workflow @ `2.0.0` → tag `v2.0.0` → CircleCI publishes → `stackhawk/stackhawk@2.0.0` in registry

> Note to watch on first run: the tag is created with the default `GITHUB_TOKEN`. External webhooks (CircleCI) fire on such tag pushes, so CircleCI should pick it up; if it doesn't, switch the tag push to a PAT.

Refs ENG-98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)