### PR TITLE
fix: pin orb usage examples to @2.0.0 (RC011) to unblock publish [ENG-98]

### DIFF
--- a/src/examples/hawkscan_local.yml
+++ b/src/examples/hawkscan_local.yml
@@ -15,7 +15,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    stackhawk: stackhawk/stackhawk@x.y
+    stackhawk: stackhawk/stackhawk@2.0.0
   workflows:
     scan-local:
       jobs:

--- a/src/examples/hawkscan_remote.yml
+++ b/src/examples/hawkscan_remote.yml
@@ -13,7 +13,7 @@ description: |
 usage:
   version: 2.1
   orbs:
-    stackhawk: stackhawk/stackhawk@x.y
+    stackhawk: stackhawk/stackhawk@2.0.0
   workflows:
     scan-remote:
       jobs:


### PR DESCRIPTION
## Summary

The `v2.0.0` release tag pipeline failed at `orb-tools/review` → **RC011** ("usage examples showcase current major version"), which blocked `continue`/publish — so 2.0.0 never made it to the registry.

RC011 is **skipped off-tag** (no major to compare), so it passed on branch/master and only fired on the release tag, comparing the example orb version to the tag's major (`2`). Our `src/examples/*.yml` used `@x.y` (no parseable version → `null`).

### Change
- `src/examples/hawkscan_local.yml` + `hawkscan_remote.yml`: `stackhawk/stackhawk@x.y` → `@2.0.0`. Satisfies RC011 (major `2` ≥ current major `2`) and stays valid across the 2.x line.

## How does this make you feel?
![almost there](https://media.giphy.com/media/nYYtQdLqwwlTe3ccKh/giphy.gif)

## Test plan
- [x] `circleci orb pack ./src | circleci orb validate -` passes
- [x] yamllint clean
- [ ] After merge + re-release: `review` passes on the tag → `orb-tools/publish` runs → `stackhawk/stackhawk@2.0.0` in registry

Refs ENG-98. Unblocks the v2.0.0 publish (the prior tag run failed RC011 before publishing, so nothing shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)