### PR TITLE
fix: review orb_name -> short alias 'stackhawk' for RC011 [ENG-98]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,7 +19,7 @@ workflows:
       - orb-tools/pack:
           filters: *filters
       - orb-tools/review:
-          orb_name: stackhawk/stackhawk
+          orb_name: stackhawk
           filters: *filters
       - orb-tools/continue:
           orb_name: stackhawk


### PR DESCRIPTION
## Summary

The v2.0.0 re-release still failed `orb-tools/review` → **RC011** on the tag — but the version (`@2.0.0`, from #25) was correct; the **lookup key** was wrong.

RC011 reads the example version via `yq '.usage.orbs["<orb_name>"]'`, where `<orb_name>` is the `review` job's `orb_name`. We passed the full slug `stackhawk/stackhawk`, but the examples key the orb by its alias **`stackhawk`**, so yq returned `null` → RC011 failed → no publish. orb-tools passes the short name (`orb-tools`) for exactly this reason.

### Change
- `.circleci/config.yml`: `orb-tools/review` `orb_name: stackhawk/stackhawk` → **`stackhawk`** (matches the example alias key). `continue` already uses the `stackhawk` alias; `publish` keeps the full `stackhawk/stackhawk` slug.

### Verified locally
```
yq '.usage.orbs["stackhawk/stackhawk"]' → null     (the failing lookup)
yq '.usage.orbs["stackhawk"]'           → stackhawk/stackhawk@2.0.0   (major 2 == tag major)
```

## How does this make you feel?
![almost there](https://media.giphy.com/media/nYYtQdLqwwlTe3ccKh/giphy.gif)

## Test plan
- [x] `circleci config validate` passes
- [x] `yq` lookup by `stackhawk` resolves to `@2.0.0` in both examples
- [ ] After merge + re-release: RC011 passes on the tag → publish → `stackhawk/stackhawk@2.0.0` in registry

Refs ENG-98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)